### PR TITLE
feat: Add proxy-path (17) DHCP option

### DIFF
--- a/pkg/transcoding/dhcp.go
+++ b/pkg/transcoding/dhcp.go
@@ -12,6 +12,7 @@ const (
 	DHCPBaseClassID                 = "PXEClient"
 	DHCPEFIArch                     = 7  // X86-64_EFI
 	DHCPOptUUIDGUIDClientIdentifier = 97 // Option: (97) UUID/GUID-based Client Identifier
+	DHCPRootPath                    = 17 // Option: (17) Root Path
 )
 
 type DecodedDHCPPacket struct {
@@ -98,6 +99,10 @@ func EncodeDHCPPacket(
 			layers.NewDHCPOption(
 				layers.DHCPOptClassID,
 				[]byte(DHCPBaseClassID),
+			),
+			layers.NewDHCPOption(
+				DHCPRootPath,
+				[]byte(advertisedIP.String()),
 			),
 			clientIdentifierOpt,
 		},

--- a/pkg/transcoding/proxy_dhcp.go
+++ b/pkg/transcoding/proxy_dhcp.go
@@ -68,6 +68,10 @@ func EncodeProxyDHCPPacket(
 				layers.DHCPOptVendorOption,
 				serializedSubOptions,
 			),
+			layers.NewDHCPOption(
+				DHCPRootPath,
+				[]byte(advertisedIP.String()),
+			),
 		},
 	}
 


### PR DESCRIPTION
This adds the proxy-path DHCP option so that i.e. iPXE can chain from a relative path.