### PR TITLE
Add create empty file option to file explorer

### DIFF
--- a/pkg/components/data_shell.go
+++ b/pkg/components/data_shell.go
@@ -36,10 +36,11 @@ type DataShell struct {
 	TFTPShareLink url.URL
 	SharePath     func(string)
 
-	CreatePath func(string)
-	DeletePath func(string)
-	MovePath   func(string, string)
-	CopyPath   func(string, string)
+	CreatePath      func(string)
+	CreateEmptyFile func(string)
+	DeletePath      func(string)
+	MovePath        func(string, string)
+	CopyPath        func(string, string)
 
 	EditPathContents    string
 	SetEditPathContents func(string)
@@ -226,10 +227,11 @@ func (c *DataShell) Render() app.UI {
 																							TFTPShareLink: c.TFTPShareLink,
 																							SharePath:     c.SharePath,
 
-																							CreatePath: c.CreatePath,
-																							DeletePath: c.DeletePath,
-																							MovePath:   c.MovePath,
-																							CopyPath:   c.CopyPath,
+																							CreatePath:      c.CreatePath,
+																							CreateEmptyFile: c.CreateEmptyFile,
+																							DeletePath:      c.DeletePath,
+																							MovePath:        c.MovePath,
+																							CopyPath:        c.CopyPath,
 
 																							EditPathContents:    c.EditPathContents,
 																							SetEditPathContents: c.SetEditPathContents,

--- a/pkg/components/home.go
+++ b/pkg/components/home.go
@@ -93,10 +93,11 @@ func (c *Home) Render() app.UI {
 											TFTPShareLink: dpcp.TFTPShareLink,
 											SharePath:     dpcp.SharePath,
 
-											CreatePath: dpcp.CreatePath,
-											DeletePath: dpcp.DeletePath,
-											MovePath:   dpcp.MovePath,
-											CopyPath:   dpcp.CopyPath,
+											CreatePath:      dpcp.CreatePath,
+											CreateEmptyFile: dpcp.CreateEmptyFile,
+											DeletePath:      dpcp.DeletePath,
+											MovePath:        dpcp.MovePath,
+											CopyPath:        dpcp.CopyPath,
 
 											EditPathContents:    dpcp.EditPathContents,
 											SetEditPathContents: dpcp.SetEditPathContents,


### PR DESCRIPTION
This allows creating an empty file from the PWA; this way, config or other text files need not be manually created with WebDAV.