### PR TITLE
Improve reliability over wifi

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,10 @@ Have any questions or need help? Chat with us [on Matrix](https://matrix.to/#/#b
 
 If you want to have persistent inventory of services and nodes on your network or turn the nodes in it on remotely, check out [liwasc](https://github.com/pojntfx/liwasc)!
 
+## Troubleshooting
+
+- If you run bofied over Wifi or advertise your Wifi adapter's IP, old PXE clients might hang at PXE errors such as `TFTP cannot read from connection` or `TFTP read timeout` due to very slow transfer speeds or other problems with complex network topologies. To fix this, disconnect other network adapters - i.e. if you're running bofied on a laptop with both a Wifi and an ethernet card and you advertise the Wifi card's IP, disconnect the ethernet cable. bofied's log and [Wireshark](https://www.wireshark.org/) might also give you more insights in such situations. For the best reliablity, run bofied on a wired connection.
+
 ## License
 
 bofied (c) 2021 Felix Pojtinger and contributors

--- a/README.md
+++ b/README.md
@@ -97,12 +97,8 @@ $ docker run \
     --name bofied-backend \
     -d \
     --restart always \
+    --net host \
     --cap-add NET_BIND_SERVICE \
-    -p 67:67/udp \
-    -p 4011:4011/udp \
-    -p 69:69/udp \
-    -p 15256:15256/tcp \
-    -p 15257:15257/tcp \
     -v ${HOME}/.local/share/bofied:/root/.local/share/bofied:z \
     -e BOFIED_BACKEND_OIDCISSUER=https://pojntfx.eu.auth0.com/ \
     -e BOFIED_BACKEND_OIDCCLIENTID=myoidcclientid \

--- a/pkg/servers/tftp.go
+++ b/pkg/servers/tftp.go
@@ -52,9 +52,15 @@ func (s *TFTPServer) ListenAndServe() error {
 
 			// Send the file to the client
 			n, err := rf.ReadFrom(file)
+			if err != nil {
+				s.EventHandler.Emit(`could not sent file "%v" to client "%v": %v`, fullFilename, raddr.String(), err)
+
+				return err
+			}
+
 			s.EventHandler.Emit(`sent file "%v" (%v bytes) to client "%v"`, fullFilename, n, raddr.String())
 
-			return err
+			return nil
 		},
 		nil,
 	)


### PR DESCRIPTION
This adds some docs and better error handling for complex network configurations such as running bofied over Wifi; it also fixes the docs to use `--net host` for DHCP support by using the host networking stack.