### PR TITLE
Log HTTP GET requests like with TFTP

### DIFF
--- a/cmd/bofied-backend/main.go
+++ b/cmd/bofied-backend/main.go
@@ -96,7 +96,7 @@ For more information, please visit https://github.com/pojntfx/bofied.`,
 				eventsHandler,
 			)
 			grpcServer, grpcServerHandler := servers.NewGRPCServer(viper.GetString(grpcListenAddressKey), eventsService, metadataService)
-			extendedHTTPServer := servers.NewExtendedHTTPServer(viper.GetString(workingDirKey), viper.GetString(webDAVAndHTTPListenAddressKey), oidcValidator, grpcServerHandler)
+			extendedHTTPServer := servers.NewExtendedHTTPServer(viper.GetString(workingDirKey), viper.GetString(webDAVAndHTTPListenAddressKey), oidcValidator, grpcServerHandler, eventsHandler)
 
 			// Start servers
 			log.Printf(

--- a/pkg/eventing/http_logging.go
+++ b/pkg/eventing/http_logging.go
@@ -1,0 +1,15 @@
+package eventing
+
+import (
+	"net/http"
+)
+
+func LogRequestHandler(h http.Handler, eventHandler *EventHandler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			eventHandler.Emit(`sending file "%v" to client "%v" with user agent "%v"`, r.URL.Path, r.RemoteAddr, r.UserAgent())
+		}
+
+		h.ServeHTTP(w, r)
+	})
+}

--- a/pkg/servers/tftp.go
+++ b/pkg/servers/tftp.go
@@ -14,7 +14,7 @@ import (
 type TFTPServer struct {
 	FileServer
 
-	EventHandler *eventing.EventHandler
+	eventHandler *eventing.EventHandler
 }
 
 func NewTFTPServer(workingDir string, listenAddress string, eventHandler *eventing.EventHandler) *TFTPServer {
@@ -24,7 +24,7 @@ func NewTFTPServer(workingDir string, listenAddress string, eventHandler *eventi
 			listenAddress: listenAddress,
 		},
 
-		EventHandler: eventHandler,
+		eventHandler: eventHandler,
 	}
 }
 
@@ -37,7 +37,7 @@ func (s *TFTPServer) ListenAndServe() error {
 			// Prevent accessing any parent directories
 			fullFilename := filepath.Join(s.workingDir, filename)
 			if strings.Contains(filename, "..") {
-				s.EventHandler.Emit(`could not send file: get request to file "%v" by client "%v" blocked because it is located outside the working directory "%v"`, fullFilename, raddr.String(), s.workingDir)
+				s.eventHandler.Emit(`could not send file: get request to file "%v" by client "%v" blocked because it is located outside the working directory "%v"`, fullFilename, raddr.String(), s.workingDir)
 
 				return errors.New("unauthorized: tried to access file outside working directory")
 			}
@@ -45,7 +45,7 @@ func (s *TFTPServer) ListenAndServe() error {
 			// Open file to send
 			file, err := os.Open(fullFilename)
 			if err != nil {
-				s.EventHandler.Emit(`could not open file "%v" for client "%v": %v`, fullFilename, raddr.String(), err)
+				s.eventHandler.Emit(`could not open file "%v" for client "%v": %v`, fullFilename, raddr.String(), err)
 
 				return err
 			}
@@ -53,12 +53,12 @@ func (s *TFTPServer) ListenAndServe() error {
 			// Send the file to the client
 			n, err := rf.ReadFrom(file)
 			if err != nil {
-				s.EventHandler.Emit(`could not sent file "%v" to client "%v": %v`, fullFilename, raddr.String(), err)
+				s.eventHandler.Emit(`could not sent file "%v" to client "%v": %v`, fullFilename, raddr.String(), err)
 
 				return err
 			}
 
-			s.EventHandler.Emit(`sent file "%v" (%v bytes) to client "%v"`, fullFilename, n, raddr.String())
+			s.eventHandler.Emit(`sent file "%v" (%v bytes) to client "%v"`, fullFilename, n, raddr.String())
 
 			return nil
 		},


### PR DESCRIPTION
This standardizes logging behaviours accross TFTP and HTTP; latter were previously not being logged.